### PR TITLE
Add task expiration background job

### DIFF
--- a/jobs/taskExpiration.ts
+++ b/jobs/taskExpiration.ts
@@ -1,0 +1,42 @@
+import { sendReviewNotification } from '../services/notifications/send';
+import {
+  getPendingSubmissions,
+  autoApproveSubmission,
+  releaseRewards,
+  Submission,
+} from '../services/submissions';
+import { logAuditAction } from '../services/audit';
+
+const HOUR = 60 * 60 * 1000;
+const REMINDER_THRESHOLD = 72; // hours
+const AUTO_APPROVE_THRESHOLD = 96; // hours
+
+async function processSubmission(submission: Submission, now: Date): Promise<void> {
+  const ageHours = (now.getTime() - submission.submittedAt.getTime()) / HOUR;
+
+  if (ageHours >= AUTO_APPROVE_THRESHOLD) {
+    await autoApproveSubmission(submission.id);
+    await releaseRewards(submission.id);
+    await logAuditAction({
+      submissionId: submission.id,
+      action: 'auto-approved after reviewer timeout',
+    });
+  } else if (ageHours >= REMINDER_THRESHOLD) {
+    await sendReviewNotification(submission.reviewerId, submission.id);
+  }
+}
+
+export async function checkPendingSubmissions(): Promise<void> {
+  const submissions = await getPendingSubmissions();
+  const now = new Date();
+  for (const submission of submissions) {
+    await processSubmission(submission, now);
+  }
+}
+
+// Run the check every hour.
+setInterval(() => {
+  checkPendingSubmissions().catch((err) =>
+    console.error('taskExpiration job failed', err)
+  );
+}, HOUR);

--- a/services/audit.ts
+++ b/services/audit.ts
@@ -1,0 +1,3 @@
+export async function logAuditAction(params: { submissionId: string; action: string }): Promise<void> {
+  // Placeholder: record action in audit log table.
+}

--- a/services/notifications/send.ts
+++ b/services/notifications/send.ts
@@ -1,0 +1,4 @@
+export async function sendReviewNotification(reviewerId: string, submissionId: string): Promise<void> {
+  // Placeholder: implement real notification logic.
+  console.log(`Notified reviewer ${reviewerId} about submission ${submissionId}`);
+}

--- a/services/submissions.ts
+++ b/services/submissions.ts
@@ -1,0 +1,19 @@
+export interface Submission {
+  id: string;
+  reviewerId: string;
+  submittedAt: Date;
+  status: 'pending' | 'approved';
+}
+
+export async function getPendingSubmissions(): Promise<Submission[]> {
+  // Placeholder: replace with real database query.
+  return [];
+}
+
+export async function autoApproveSubmission(id: string): Promise<void> {
+  // Placeholder: mark submission approved in database.
+}
+
+export async function releaseRewards(id: string): Promise<void> {
+  // Placeholder: release rewards to submitter.
+}


### PR DESCRIPTION
## Summary
- add hourly task expiration job that reminds reviewers and auto-approves overdue submissions
- add placeholder notification sender for reviewer reminders
- stub submission and audit services used by the job

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(failed: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689d8409552c832392a2c05a392a7a22