### PR TITLE
feat: add screenshot upload validation

### DIFF
--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+
+interface FileUploaderProps {
+  onChange?: (files: FileList | null) => void;
+  multiple?: boolean;
+}
+
+/**
+ * Simple file upload component restricted to PNG and JPEG images.
+ */
+const FileUploader: React.FC<FileUploaderProps> = ({ onChange, multiple = false }) => {
+  return (
+    <input
+      type="file"
+      accept="image/png,image/jpeg"
+      onChange={(e) => onChange?.(e.target.files)}
+      multiple={multiple}
+    />
+  );
+};
+
+export default FileUploader;

--- a/pages/api/tasks/submit.ts
+++ b/pages/api/tasks/submit.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Task } from "../../../types/task";
+
+const ALLOWED_MIME_TYPES = ["image/png", "image/jpeg"];
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const { task, screenshots } = req.body as {
+    task: Task;
+    screenshots: { mime: string }[];
+  };
+
+  const requirements = task?.screenshotRequirements;
+  if (!requirements) {
+    return res.status(400).json({ error: "Missing screenshot requirements" });
+  }
+
+  const { count } = requirements;
+  if (typeof count !== "number" || count < 0 || count > 2) {
+    return res.status(400).json({ error: "Invalid screenshot count" });
+  }
+
+  if (!Array.isArray(screenshots) || screenshots.length !== count) {
+    return res.status(400).json({ error: "Incorrect number of screenshots" });
+  }
+
+  for (const file of screenshots) {
+    if (!ALLOWED_MIME_TYPES.includes(file.mime)) {
+      return res.status(400).json({ error: "Unsupported screenshot type" });
+    }
+  }
+
+  return res.status(200).json({ success: true });
+}

--- a/types/task.ts
+++ b/types/task.ts
@@ -1,0 +1,13 @@
+export interface ScreenshotRequirements {
+  /**
+   * Number of screenshots required to complete the task (0-2).
+   */
+  count: 0 | 1 | 2;
+  /** Description of what the screenshots should demonstrate. */
+  description: string;
+}
+
+export interface Task {
+  // Additional task fields could go here such as id, title, description, etc.
+  screenshotRequirements: ScreenshotRequirements;
+}


### PR DESCRIPTION
## Summary
- add reusable FileUploader component limited to PNG/JPEG
- extend Task type with screenshotRequirements
- validate screenshot count and mime types in task submission API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d84076d288323ad050ab028bc7b5b