### PR TITLE
feat: add proof question selection

### DIFF
--- a/app/task/submit/page.tsx
+++ b/app/task/submit/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { Task, selectProofQuestions } from '../../../lib/tasks';
+
+const demoTask: Task = {
+  id: 'demo',
+  title: 'Demo task',
+  proofQuestions: [
+    { id: 'q1', text: 'Provide a mandatory proof', isMandatory: true },
+    { id: 'q2', text: 'Optional proof one', isMandatory: false },
+    { id: 'q3', text: 'Optional proof two', isMandatory: false }
+  ]
+};
+
+export default function SubmitTaskPage() {
+  const questions = selectProofQuestions(demoTask);
+  const [answers, setAnswers] = useState<string[]>(Array(questions.length).fill(''));
+  const [error, setError] = useState('');
+
+  const handleChange = (index: number, value: string) => {
+    const copy = [...answers];
+    copy[index] = value;
+    setAnswers(copy);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (answers.some((a) => !a.trim())) {
+      setError('All proof questions require a response.');
+      return;
+    }
+    setError('');
+    alert('Submission recorded');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {questions.map((q, i) => (
+        <div key={q.id} className="flex flex-col">
+          <label className="mb-1">{q.text}</label>
+          <input
+            type="text"
+            value={answers[i]}
+            onChange={(e) => handleChange(i, e.target.value)}
+            required
+            className="border p-2"
+          />
+        </div>
+      ))}
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -1,0 +1,35 @@
+export interface ProofQuestion {
+  id: string;
+  text: string;
+  isMandatory: boolean;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  /**
+   * Up to five questions that the worker must answer as proof of work.
+   */
+  proofQuestions: ProofQuestion[];
+}
+
+/**
+ * Selects proof questions for a booking. All mandatory questions are
+ * included and, if available, one random optional question.
+ */
+export function selectProofQuestions(task: Task): ProofQuestion[] {
+  if (task.proofQuestions.length > 5) {
+    throw new Error("A task can have at most five proof questions");
+  }
+
+  const mandatory = task.proofQuestions.filter((q) => q.isMandatory);
+  const optional = task.proofQuestions.filter((q) => !q.isMandatory);
+
+  const selected = [...mandatory];
+  if (optional.length > 0) {
+    const random = optional[Math.floor(Math.random() * optional.length)];
+    selected.push(random);
+  }
+
+  return selected;
+}


### PR DESCRIPTION
## Summary
- add task model with proof questions and auto-selection helper
- render submission form that enforces answering selected questions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d8404e3548323a302ae54b55cdff4