### PR TITLE
Add task instruction booking and review logic

### DIFF
--- a/services/taskInstructions.ts
+++ b/services/taskInstructions.ts
@@ -1,0 +1,9 @@
+export interface TaskInstruction {
+  taskId: string;
+  instructionText: string;
+  isAssigned: boolean;
+  assignedTo: string | null;
+  expiresAt: Date | null;
+}
+
+export const taskInstructions: TaskInstruction[] = [];

--- a/services/tasks/book.ts
+++ b/services/tasks/book.ts
@@ -1,0 +1,33 @@
+import { taskInstructions, TaskInstruction } from '../taskInstructions';
+
+/**
+ * Assigns an available instruction for the given task to a user.
+ * The assignment marks the instruction as used and sets an expiry based on the booking window.
+ * @param taskId id of the task being booked
+ * @param userId id of the participant booking the task
+ * @param bookingWindowMs duration in milliseconds for how long the instruction is reserved
+ * @returns the assigned instruction or null if none are available
+ */
+export function bookTask(
+  taskId: string,
+  userId: string,
+  bookingWindowMs: number
+): TaskInstruction | null {
+  const now = new Date();
+
+  // find first instruction that is not currently assigned or has expired
+  const instruction = taskInstructions.find((inst) =>
+    inst.taskId === taskId &&
+    (!inst.isAssigned || (inst.expiresAt !== null && inst.expiresAt <= now))
+  );
+
+  if (!instruction) {
+    return null;
+  }
+
+  instruction.isAssigned = true;
+  instruction.assignedTo = userId;
+  instruction.expiresAt = new Date(now.getTime() + bookingWindowMs);
+
+  return instruction;
+}

--- a/services/tasks/review.ts
+++ b/services/tasks/review.ts
@@ -1,0 +1,33 @@
+import { taskInstructions } from '../taskInstructions';
+
+/**
+ * Validates a participant's submission against the instruction assigned to them.
+ * Throws an error if the submission is invalid.
+ * @param taskId id of the task being reviewed
+ * @param userId id of the participant
+ * @param submissionText text submitted by the participant
+ */
+export function reviewSubmission(
+  taskId: string,
+  userId: string,
+  submissionText: string
+): boolean {
+  const now = new Date();
+  const instruction = taskInstructions.find(
+    (inst) =>
+      inst.taskId === taskId &&
+      inst.assignedTo === userId &&
+      inst.expiresAt !== null &&
+      inst.expiresAt > now
+  );
+
+  if (!instruction) {
+    throw new Error('No valid instruction assigned to this participant.');
+  }
+
+  if (instruction.instructionText.trim() !== submissionText.trim()) {
+    throw new Error('Submission does not match assigned instruction.');
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add in-memory `task_instructions` table
- assign instructions during booking with expiry
- validate submission against assigned instructions

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm install --save-dev eslint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_689d8401849483238b474d4142b86063