### PR TITLE
Add category metadata and validation

### DIFF
--- a/app/tasks/create/page.tsx
+++ b/app/tasks/create/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Category,
+  Subcategory,
+  categoryList,
+  subcategoriesFor,
+  defaultRewardFor,
+} from '@/data/categories';
+
+const initialCategory = categoryList[0];
+const initialSubcategory = subcategoriesFor(initialCategory)[0];
+
+export default function CreateTaskPage() {
+  const [category, setCategory] = useState<Category>(initialCategory);
+  const [subcategory, setSubcategory] = useState<Subcategory>(initialSubcategory);
+  const [reward, setReward] = useState<number>(
+    defaultRewardFor(initialCategory, initialSubcategory),
+  );
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCategory = e.target.value as Category;
+    setCategory(newCategory);
+    const subs = subcategoriesFor(newCategory);
+    const firstSub = subs[0];
+    setSubcategory(firstSub);
+    setReward(defaultRewardFor(newCategory, firstSub));
+  };
+
+  const handleSubcategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newSub = e.target.value as Subcategory;
+    setSubcategory(newSub);
+    setReward(defaultRewardFor(category, newSub));
+  };
+
+  return (
+    <form className="flex flex-col gap-4 p-4 max-w-md">
+      <div>
+        <label className="block mb-1">Category</label>
+        <select
+          className="border p-2 w-full"
+          value={category}
+          onChange={handleCategoryChange}
+        >
+          {categoryList.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block mb-1">Subcategory</label>
+        <select
+          className="border p-2 w-full"
+          value={subcategory}
+          onChange={handleSubcategoryChange}
+        >
+          {subcategoriesFor(category).map((sub) => (
+            <option key={sub} value={sub}>
+              {sub}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block mb-1">Reward Per Participant</label>
+        <input
+          type="number"
+          step="0.01"
+          className="border p-2 w-full"
+          value={reward}
+          onChange={(e) => setReward(parseFloat(e.target.value))}
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="bg-blue-600 text-white rounded px-4 py-2"
+      >
+        Create Task
+      </button>
+    </form>
+  );
+}

--- a/data/categories.ts
+++ b/data/categories.ts
@@ -1,0 +1,41 @@
+export enum Category {
+  DATA_COLLECTION = 'DATA_COLLECTION',
+  DATA_LABELING = 'DATA_LABELING',
+}
+
+export enum Subcategory {
+  TEXT_TRANSCRIPTION = 'TEXT_TRANSCRIPTION',
+  DATA_ENTRY = 'DATA_ENTRY',
+  IMAGE_ANNOTATION = 'IMAGE_ANNOTATION',
+  SENTIMENT_ANALYSIS = 'SENTIMENT_ANALYSIS',
+}
+
+// Nested record of categories -> subcategories -> default reward per participant
+export const categories: Record<Category, Record<Subcategory, number>> = {
+  [Category.DATA_COLLECTION]: {
+    [Subcategory.TEXT_TRANSCRIPTION]: 0.2,
+    [Subcategory.DATA_ENTRY]: 0.1,
+  },
+  [Category.DATA_LABELING]: {
+    [Subcategory.IMAGE_ANNOTATION]: 0.15,
+    [Subcategory.SENTIMENT_ANALYSIS]: 0.05,
+  },
+};
+
+export const categoryList = Object.values(Category);
+
+export function subcategoriesFor(category: Category): Subcategory[] {
+  return Object.keys(categories[category]) as Subcategory[];
+}
+
+export function defaultRewardFor(category: Category, subcategory: Subcategory): number {
+  return categories[category][subcategory];
+}
+
+export function isValidCategory(category: any): category is Category {
+  return categoryList.includes(category);
+}
+
+export function isValidSubcategory(category: Category, subcategory: any): subcategory is Subcategory {
+  return subcategoriesFor(category).includes(subcategory as Subcategory);
+}

--- a/pages/api/tasks/index.ts
+++ b/pages/api/tasks/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  isValidCategory,
+  isValidSubcategory,
+  Category,
+} from '@/data/categories';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { category, subcategory } = req.body;
+
+  if (!isValidCategory(category)) {
+    return res.status(400).json({ error: 'Invalid category' });
+  }
+
+  const cat = category as Category;
+  if (!isValidSubcategory(cat, subcategory)) {
+    return res.status(400).json({ error: 'Invalid subcategory' });
+  }
+
+  // Placeholder success response
+  return res.status(200).json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add centralized category and subcategory enums with default rewards
- build task creation page that uses category data for dropdowns and reward suggestions
- validate categories/subcategories in task API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d840040b083239bc40193656b0811