### PR TITLE
Add device and region filters to tasks

### DIFF
--- a/app/task/create/page.tsx
+++ b/app/task/create/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import { Task } from '../../../models/Task';
+
+const deviceOptions = ['desktop', 'mobile', 'tablet'];
+const regionOptions = ['NA', 'SA', 'EU', 'AF', 'AS', 'OC'];
+const countryOptions = ['US', 'CA', 'GB', 'FR', 'DE', 'IN', 'CN'];
+
+export default function CreateTaskPage() {
+  const [allowedDevices, setAllowedDevices] = useState<string[]>([]);
+  const [allowedRegions, setAllowedRegions] = useState<string[]>([]);
+  const [excludedCountries, setExcludedCountries] = useState<string[]>([]);
+
+  const handleMultiChange = (
+    setter: (value: string[]) => void,
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const values = Array.from(e.target.selectedOptions).map((o) => o.value);
+    setter(values);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const task: Task = {
+      id: 'temp-id',
+      title: String(formData.get('title') || ''),
+      allowedDevices,
+      allowedRegions,
+      excludedCountries,
+    };
+    console.log('create task', task);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <input
+        name="title"
+        placeholder="Task title"
+        className="border p-2"
+      />
+
+      <label className="font-bold">Allowed Devices</label>
+      <select
+        multiple
+        value={allowedDevices}
+        onChange={(e) => handleMultiChange(setAllowedDevices, e)}
+        className="border p-2 h-32"
+      >
+        {deviceOptions.map((d) => (
+          <option key={d} value={d}>
+            {d}
+          </option>
+        ))}
+      </select>
+
+      <label className="font-bold">Allowed Regions</label>
+      <select
+        multiple
+        value={allowedRegions}
+        onChange={(e) => handleMultiChange(setAllowedRegions, e)}
+        className="border p-2 h-32"
+      >
+        {regionOptions.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+
+      <label className="font-bold">Excluded Countries</label>
+      <select
+        multiple
+        value={excludedCountries}
+        onChange={(e) => handleMultiChange(setExcludedCountries, e)}
+        className="border p-2 h-32"
+      >
+        {countryOptions.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+
+      <button type="submit" className="bg-blue-500 text-white p-2">
+        Create Task
+      </button>
+    </form>
+  );
+}

--- a/models/Task.ts
+++ b/models/Task.ts
@@ -1,0 +1,7 @@
+export interface Task {
+  id: string;
+  title: string;
+  allowedDevices: string[];
+  allowedRegions: string[];
+  excludedCountries: string[];
+}

--- a/services/tasks/assign.ts
+++ b/services/tasks/assign.ts
@@ -1,0 +1,29 @@
+import { Task } from '../../models/Task';
+
+export interface Participant {
+  device: string;
+  region: string;
+  country: string;
+}
+
+export function canAssign(task: Task, participant: Participant): boolean {
+  if (
+    task.allowedDevices.length > 0 &&
+    !task.allowedDevices.includes(participant.device)
+  ) {
+    return false;
+  }
+
+  if (
+    task.allowedRegions.length > 0 &&
+    !task.allowedRegions.includes(participant.region)
+  ) {
+    return false;
+  }
+
+  if (task.excludedCountries.includes(participant.country)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add Task model fields for device, region and country filters
- create task creation form with multi-select inputs
- check participant eligibility against device and region filters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_689d83fd11c083239dc4ec4ec51769f0