### PR TITLE
feat: add dashboards and role-based sidebars

### DIFF
--- a/app/dashboard/admin/layout.tsx
+++ b/app/dashboard/admin/layout.tsx
@@ -1,0 +1,14 @@
+import AdminSidebar from "@/components/sidebar/AdminSidebar";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex">
+      <AdminSidebar />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Admin Overview</h1>;
+}

--- a/app/dashboard/admin/reports/page.tsx
+++ b/app/dashboard/admin/reports/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Reports</h1>;
+}

--- a/app/dashboard/admin/settings/page.tsx
+++ b/app/dashboard/admin/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Admin Settings</h1>;
+}

--- a/app/dashboard/admin/tasks/page.tsx
+++ b/app/dashboard/admin/tasks/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Manage Tasks</h1>;
+}

--- a/app/dashboard/admin/users/page.tsx
+++ b/app/dashboard/admin/users/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Manage Users</h1>;
+}

--- a/app/dashboard/subadmin/kyc/page.tsx
+++ b/app/dashboard/subadmin/kyc/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>KYC Reviews</h1>;
+}

--- a/app/dashboard/subadmin/layout.tsx
+++ b/app/dashboard/subadmin/layout.tsx
@@ -1,0 +1,14 @@
+import SubAdminSidebar from "@/components/sidebar/SubAdminSidebar";
+
+export default function SubAdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex">
+      <SubAdminSidebar />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/app/dashboard/subadmin/page.tsx
+++ b/app/dashboard/subadmin/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Sub Admin Dashboard</h1>;
+}

--- a/app/dashboard/subadmin/settings/page.tsx
+++ b/app/dashboard/subadmin/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Sub Admin Settings</h1>;
+}

--- a/app/dashboard/subadmin/tasks/page.tsx
+++ b/app/dashboard/subadmin/tasks/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Task Approvals</h1>;
+}

--- a/app/dashboard/subadmin/withdrawals/page.tsx
+++ b/app/dashboard/subadmin/withdrawals/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Withdrawal Reviews</h1>;
+}

--- a/app/dashboard/user/add-balance/page.tsx
+++ b/app/dashboard/user/add-balance/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Add Balance</h1>;
+}

--- a/app/dashboard/user/history/page.tsx
+++ b/app/dashboard/user/history/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Task History</h1>;
+}

--- a/app/dashboard/user/kyc/page.tsx
+++ b/app/dashboard/user/kyc/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>KYC Verification</h1>;
+}

--- a/app/dashboard/user/layout.tsx
+++ b/app/dashboard/user/layout.tsx
@@ -1,0 +1,14 @@
+import UserSidebar from "@/components/sidebar/UserSidebar";
+
+export default function UserLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex">
+      <UserSidebar />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/app/dashboard/user/page.tsx
+++ b/app/dashboard/user/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>User Dashboard</h1>;
+}

--- a/app/dashboard/user/post-task/page.tsx
+++ b/app/dashboard/user/post-task/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Post Task</h1>;
+}

--- a/app/dashboard/user/settings/page.tsx
+++ b/app/dashboard/user/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>User Settings</h1>;
+}

--- a/app/dashboard/user/tasks/page.tsx
+++ b/app/dashboard/user/tasks/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Task List</h1>;
+}

--- a/app/dashboard/user/transactions/page.tsx
+++ b/app/dashboard/user/transactions/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Transaction History</h1>;
+}

--- a/app/dashboard/user/withdraw/page.tsx
+++ b/app/dashboard/user/withdraw/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Withdraw</h1>;
+}

--- a/components/sidebar/AdminSidebar.tsx
+++ b/components/sidebar/AdminSidebar.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+const AdminSidebar = () => (
+  <aside className="w-64 min-h-screen bg-gray-100 p-4">
+    <nav>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/dashboard/admin">Overview</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/admin/users">Manage Users</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/admin/tasks">Manage Tasks</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/admin/reports">Reports</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/admin/settings">Settings</Link>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+);
+
+export default AdminSidebar;

--- a/components/sidebar/SubAdminSidebar.tsx
+++ b/components/sidebar/SubAdminSidebar.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+const SubAdminSidebar = () => (
+  <aside className="w-64 min-h-screen bg-gray-100 p-4">
+    <nav>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/dashboard/subadmin/tasks">Task Approvals</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/subadmin/kyc">KYC Reviews</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/subadmin/withdrawals">Withdrawal Reviews</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/subadmin/settings">Settings</Link>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+);
+
+export default SubAdminSidebar;

--- a/components/sidebar/UserSidebar.tsx
+++ b/components/sidebar/UserSidebar.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+const UserSidebar = () => (
+  <aside className="w-64 min-h-screen bg-gray-100 p-4">
+    <nav>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/dashboard/user/tasks">Task List</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/history">Task History</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/kyc">KYC Verification</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/post-task">Post Task</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/add-balance">Add Balance</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/withdraw">Withdraw</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/transactions">Transaction History</Link>
+        </li>
+        <li>
+          <Link href="/dashboard/user/settings">Settings</Link>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+);
+
+export default UserSidebar;


### PR DESCRIPTION
## Summary
- add user dashboard with sidebar for tasks, balance management, and settings
- create admin and sub-admin dashboards with management sidebars
- include layouts that render role-specific sidebars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_689d82f072d08323855c5619d3c6c263